### PR TITLE
Add Directory Path Argument Support To Dirtree

### DIFF
--- a/dirtree.go
+++ b/dirtree.go
@@ -4,15 +4,26 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	gitignore "github.com/sabhiram/go-gitignore"
 )
 
 func main() {
-	rootDir := "."
+	var rootDir string
+
+	if len(os.Args) == 2 {
+		rootDir = strings.Join(os.Args[1:2], "")
+	} else if len(os.Args) > 2 {
+		fmt.Printf("Invalid number of arguments")
+		os.Exit(1)
+	} else {
+		rootDir = "."
+	}
 
 	fmt.Println(".")
 	printTree(rootDir, "", nil)
+
 }
 
 func shouldIgnore(path string, ignoreMatchers []*gitignore.GitIgnore) bool {

--- a/dirtree.go
+++ b/dirtree.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	gitignore "github.com/sabhiram/go-gitignore"
 )
@@ -17,17 +16,18 @@ func main() {
 		rootDir = "."
 		fmt.Println(".")
 	case 2:
-		rootDir = strings.Join(os.Args[1:2], "")
+		rootDir = os.Args[1]
 		_, err := os.Stat(rootDir)
 		if os.IsNotExist(err) {
-			fmt.Println("File does not exist")
+			fmt.Println("directory does not exist")
 			os.Exit(1)
 		}
 		if err != nil {
-			fmt.Printf("Error %v", err)
+			fmt.Println(fmt.Errorf("error: %v", err))
+			os.Exit(1)
 		}
 	default:
-		fmt.Printf("Usage: dirtree [directory]")
+		fmt.Println("Usage: dirtree [directory]")
 		os.Exit(1)
 	}
 

--- a/dirtree.go
+++ b/dirtree.go
@@ -12,18 +12,26 @@ import (
 func main() {
 	var rootDir string
 
-	if len(os.Args) == 2 {
-		rootDir = strings.Join(os.Args[1:2], "")
-	} else if len(os.Args) > 2 {
-		fmt.Printf("Invalid number of arguments")
-		os.Exit(1)
-	} else {
+	switch len(os.Args) {
+	case 1:
 		rootDir = "."
+	case 2:
+		rootDir = strings.Join(os.Args[1:2], "")
+		_, err := os.Stat(rootDir)
+		if os.IsNotExist(err) {
+			fmt.Println("File does not exist")
+			os.Exit(1)
+		}
+		if err != nil {
+			fmt.Printf("Error %v", err)
+		}
+	default:
+		fmt.Printf("Usage: dirtree [directory]")
+		os.Exit(1)
 	}
 
 	fmt.Println(".")
 	printTree(rootDir, "", nil)
-
 }
 
 func shouldIgnore(path string, ignoreMatchers []*gitignore.GitIgnore) bool {

--- a/dirtree.go
+++ b/dirtree.go
@@ -15,6 +15,7 @@ func main() {
 	switch len(os.Args) {
 	case 1:
 		rootDir = "."
+		fmt.Println(".")
 	case 2:
 		rootDir = strings.Join(os.Args[1:2], "")
 		_, err := os.Stat(rootDir)
@@ -30,7 +31,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	fmt.Println(".")
 	printTree(rootDir, "", nil)
 }
 


### PR DESCRIPTION
- Implemented command-line argument handling to allow specifying a directory path for printing the directory tree.
- Added validation to ensure only one argument is accepted; defaults to the current directory if no arguments are provided.
- Included error handling in case the directory does not exist.
- Included error handling for other cases.
- Fixes to dirtree.go as recommended in PR Review